### PR TITLE
System cases

### DIFF
--- a/lib/autocroak.xs
+++ b/lib/autocroak.xs
@@ -5,6 +5,8 @@
 #include "XSUB.h"
 #include "ppport.h"
 
+#include <sys/wait.h>
+
 static Perl_ppaddr_t opcodes[OP_max];
 #define pragma_base "autocroak/"
 #define pragma_name pragma_base "enabled"
@@ -177,8 +179,29 @@ static OP* croak_SYSTEM(pTHX) {
 	OP* next = opcodes[OP_SYSTEM](aTHX);
 	if (autocroak_enabled()) {
 		dSP;
-		if (SvTRUE(TOPs) && !allowed_for(SYSTEM, FALSE))
-			Perl_croak(aTHX_ "Can't call system: it returned %" UVuf, SvUV(TOPs));
+		if (SvTRUE(TOPs) && !allowed_for(SYSTEM, FALSE)) {
+			int status = SvIV(TOPs);
+			SV* message;
+			if (status > 0) {
+				message = newSVpvs("Call to system failed: ");
+				if (WIFEXITED(status)) {
+					sv_catpvf(message, "exited %d", WEXITSTATUS(status));
+				}
+				else if (WIFSIGNALED(status)) {
+					int signum = WTERMSIG(status);
+					sv_catpvf(message, "got signal (%s)", strsignal(signum));
+				}
+				else {
+					assert(0);
+				}
+			}
+			else {
+				message = newSVpvs("Can't call system: ");
+				sv_caterror(message, errno);
+			}
+
+			throw_sv(message);
+		}
 	}
 	return next;
 }

--- a/t/select.t
+++ b/t/select.t
@@ -33,7 +33,7 @@ subtest ebadf => sub {
     #----------------------------------------------------------------------
 
     eval { () = select $rin, undef, undef, 0 };
-    my $err = $@;
+    $err = $@;
 
     $errstr = AutocroakTestUtils::get_errno_string('EBADF');
 

--- a/t/system.t
+++ b/t/system.t
@@ -1,0 +1,62 @@
+#! perl
+
+use strict;
+use warnings;
+
+use Test::More;
+
+use File::Temp;
+use Config;
+
+use FindBin;
+use lib "$FindBin::Bin/lib";
+
+use AutocroakTestUtils;
+
+subtest nonzero_exit => sub {
+    use autocroak;
+
+    eval { system $^X, -e => 'exit 22'; };
+    my $err = $@;
+    like( $err, qr<22>, 'nonzero exit code shows' );
+};
+
+subtest signal => sub {
+    skip "$^O doesn’t seem to play nicely with signal-based tests.", 1 if !_is_safe_to_test_with_signals();
+    use autocroak;
+
+    eval { system $^X, -e => 'kill "QUIT", $$'; };
+    my $err = $@;
+    like( $err, qr<QUIT>i, 'signal is in error' );
+};
+
+subtest failure_to_start => sub {
+    use autocroak;
+
+    my $dir = File::Temp::tempdir( CLEANUP => 1 );
+
+    my $enoent = AutocroakTestUtils::get_errno_string('ENOENT');
+
+    eval {
+        local $SIG{'__WARN__'} = sub {};
+        system "$dir/hahaha";
+    };
+    my $err = $@;
+    like( $err, qr<\Q$enoent\E>, 'ENOENT string is in error when path doesn’t exist' );
+};
+
+subtest success => sub {
+    use autocroak;
+
+    my $got = system $^X, -e => 'exit 0';
+
+    is( $got, 0, 'zero return' );
+};
+
+done_testing;
+
+#----------------------------------------------------------------------
+
+sub _is_safe_to_test_with_signals {
+    return $Config{'d_fork'};
+}


### PR DESCRIPTION
This teaches system() to report signal vs. nonzero exit, and to recognize -1 return.