### PR TITLE
allow the connect test to pass on win32

### DIFF
--- a/t/select.t
+++ b/t/select.t
@@ -17,7 +17,9 @@ use TestUtils;
 
 sub socket_pair {
 	my $listen = IO::Socket::INET->new(Listen => 10) or die $!;
-	my $connecting = IO::Socket::INET->new(PeerAddr => $listen->sockhost, PeerPort => $listen->sockport) or die $!;
+	my $addr = $listen->sockhost;
+	$addr = "localhost" if $^O eq 'MSWin32' and $addr eq "0.0.0.0";
+	my $connecting = IO::Socket::INET->new(PeerAddr => $addr, PeerPort => $listen->sockport) or die $!;
 	return ($connecting, $listen->accept);
 }
 


### PR DESCRIPTION
connect on win32 indicates it bound a listening port on any device by 0.0.0.0, which is however not a valid port to connect to when wanting to write

at least that is how i understand the situation